### PR TITLE
Add ppc64le jobs to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,11 @@ matrix:
       language: python
       python: "3.7"
     - os: linux
+      arch: ppc64le
+      dist: bionic
+      language: python
+      python: "3.7"
+    - os: linux
       dist: xenial
       language: python
       python: "pypy"


### PR DESCRIPTION
As with ARM64, Travis CI supports ppc64le ("Power") now.

I've just mimicked the job that ARM64 does: I think that provides decent coverage without bloating the test matrix too much. (We could also test pypy on Power, but I don't think it gets us too much extra value.) GitHub Actions don't support architectures other than x86 yet, so this still needs to be done on Travis for now.

If any issues come up with the Power build in future, feel free to tag me in and I'll have a look - I have access to Power systems at work.